### PR TITLE
feat: add upgrade subcommand

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -19,7 +19,15 @@ const config = {
       format: "cjs",
     },
   ],
-  external: ["*.gql", "*.yml", "fs/promises", "util", "fs", "path"],
+  external: [
+    "*.gql",
+    "*.yml",
+    "fs/promises",
+    "util",
+    "fs",
+    "path",
+    "child_process",
+  ],
   plugins: [
     typescript(),
     json(),

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -1,0 +1,29 @@
+import { exec as execProcess } from "child_process";
+import { promisify } from "util";
+import Logger, { LogLevels } from "@utils/logger";
+
+const exec = promisify(execProcess);
+
+const log = new Logger({
+  name: "upgrade",
+  level: LogLevels.debug,
+});
+
+type Installer = {
+  [key in "linux" | "darwin" | "win32" | any]: string;
+};
+
+const installers: Installer = {
+  linux: `curl -fsSL https://verto.exchange/i/linux | sh`,
+  darwin: `curl -fsSL https://verto.exchange/i/mac | sh`,
+  win32: `iwr https://verto.exchange/i/windows | iex`,
+};
+
+export default async () => {
+  if (process.platform in installers) {
+    log.info(`Installing latest release build for ${process.platform}`);
+    const { stdout, stderr } = await exec(installers[process.platform]);
+    stderr && log.error(stderr);
+    stdout && log.info(stdout);
+  }
+};

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -15,7 +15,9 @@ type Installer = {
 
 const installers: Installer = {
   linux: `curl -fsSL https://verto.exchange/i/linux | sh`,
+  /** darwin = macos */
   darwin: `curl -fsSL https://verto.exchange/i/mac | sh`,
+  /** win32 is the platform for both Windows 32bit and 64bit */
   win32: `iwr https://verto.exchange/i/windows | iex`,
 };
 

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -18,7 +18,7 @@ const installers: Installer = {
   /** darwin = macos */
   darwin: `curl -fsSL https://verto.exchange/i/mac | sh`,
   /** win32 is the platform for both Windows 32bit and 64bit */
-  win32: `iwr https://verto.exchange/i/windows | iex`,
+  win32: `PowerShell -Command "& {Invoke-WebRequest https://verto.exchange/i/windows | Invoke-Expression}"`,
 };
 
 export default async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import "@utils/console";
 import dotenv from "dotenv";
 import commander from "commander";
 import InitCommand from "@commands/init";
+import UpgradeCommand from "@commands/upgrade";
 import Log from "@utils/logger";
 import { initAPI } from "@api/index";
 import {
@@ -45,13 +46,23 @@ program
     "Verto trading post config",
     "verto.config.json"
   )
-  .action(RunCommand)
-  /**
-   * subcommand "init" to create a verto configuration file
-   */
+  .action(RunCommand);
+
+/**
+ * subcommand "init" to create a verto configuration file
+ */
+program
   .command("init")
   .description("generate a verto configuration file")
   .action(InitCommand);
+
+/**
+ * subcommand "upgrade" to upgrade to the latest trading post release
+ */
+program
+  .command("upgrade")
+  .description("upgrade to the latest trading post release")
+  .action(UpgradeCommand);
 
 /**
  * Parse the raw process arguments


### PR DESCRIPTION
Add `verto upgrade` - triggers installers

Closes #15 

**Note**: the command won't work until we release :smile: (tested with @maximousblk's release fork)